### PR TITLE
Add headers needed for compiling location provider

### DIFF
--- a/loc_api/ds_api/ds_client.c
+++ b/loc_api/ds_api/ds_client.c
@@ -142,13 +142,12 @@ void net_ev_cb(dsi_hndl_t handle, void* user_data,
 static ds_client_status_enum_type
 ds_client_qmi_ctrl_point_init(qmi_client_type *p_wds_qmi_client)
 {
-    qmi_client_type wds_qmi_client, notifier = NULL;
+    qmi_client_type wds_qmi_client;
     ds_client_status_enum_type status = E_DS_CLIENT_SUCCESS;
     qmi_service_info *p_service_info = NULL;
     uint32_t num_services = 0, num_entries = 0;
     qmi_client_error_type ret = QMI_NO_ERR;
     unsigned char no_signal = 0;
-    qmi_client_os_params os_params;
     int timeout = 0;
 
     LOC_LOGD("%s:%d]:Enter\n", __func__, __LINE__);
@@ -169,24 +168,11 @@ ds_client_qmi_ctrl_point_init(qmi_client_type *p_wds_qmi_client)
     LOC_LOGD("%s:%d]: qmi_client_get_service_list() first try ret %d, "
                    "num_services %d]\n", __func__, __LINE__, ret, num_services);
     if(ret != QMI_NO_ERR) {
-        //Register for service notification
-        ret = qmi_client_notifier_init(ds_client_service_object, &os_params, &notifier);
-        if (ret != QMI_NO_ERR) {
-            LOC_LOGE("%s:%d]: qmi_client_notifier_init failed %d\n",
-                              __func__, __LINE__, ret);
-            status = E_DS_CLIENT_FAILURE_INTERNAL;
-            goto err;
-        }
-
         do {
-            QMI_CCI_OS_SIGNAL_CLEAR(&os_params);
             ret = qmi_client_get_service_list(ds_client_service_object, NULL,
                                               NULL, &num_services);
             if(ret != QMI_NO_ERR) {
-                QMI_CCI_OS_SIGNAL_WAIT(&os_params, DS_CLIENT_SERVICE_TIMEOUT);
-                no_signal = QMI_CCI_OS_SIGNAL_TIMED_OUT(&os_params);
-                if(!no_signal)
-                    ret = qmi_client_get_service_list(ds_client_service_object, NULL,
+                ret = qmi_client_get_service_list(ds_client_service_object, NULL,
                                                       NULL, &num_services);
             }
             timeout += DS_CLIENT_SERVICE_TIMEOUT;
@@ -253,9 +239,6 @@ ds_client_qmi_ctrl_point_init(qmi_client_type *p_wds_qmi_client)
 
     status = E_DS_CLIENT_SUCCESS;
     LOC_LOGD("%s:%d]: init success\n", __func__, __LINE__);
-
-    if(notifier)
-        qmi_client_release(notifier);
 
 err:
     if(p_service_info)

--- a/loc_api/include/dsi_netctrl.h
+++ b/loc_api/include/dsi_netctrl.h
@@ -1,0 +1,139 @@
+#ifndef DSI_NETCTRL_H
+#define DSI_NETCTRL_H
+
+#include "qmi_idl_lib.h"
+
+#define QMI_WDS_GET_PROFILE_LIST_REQ_V01 0x002A
+#define QMI_WDS_GET_PROFILE_LIST_RESP_V01 0x002A
+#define QMI_WDS_GET_PROFILE_SETTINGS_REQ_V01 0x002B
+
+#define WDS_PROFILE_TYPE_3GPP_V01 0
+
+// FIXME: Find actual value?
+#define DSI_EVT_WDS_CONNECTED 0
+
+#define DSI_CALL_INFO_UMTS_PROFILE_IDX 1
+#define DSI_CALL_INFO_IP_VERSION 11
+
+#define DSI_SUCCESS 0
+#define DSI_MODE_GENERAL 0
+
+#define DSI_IP_VERSION_4 4
+#define DSI_IP_VERSION_6 6
+#define DSI_IP_VERSION_4_6 10
+
+#define WDS_PDP_TYPE_PDP_IPV4_V01 0
+#define WDS_PDP_TYPE_PDP_IPV6_V01 2
+#define WDS_PDP_TYPE_PDP_IPV4V6_V01 3
+
+#define LOC_V01_IDL_MAJOR_VERS 0x01
+#define LOC_V01_IDL_MINOR_VERS 0x23
+#define LOC_V01_IDL_TOOL_VERS  0x06
+
+typedef enum
+{
+  DSI_EVT_INVALID = 0x0,              /**< Invalid event. */
+  DSI_EVT_NET_IS_CONN,                /**< Call is connected. */
+  DSI_EVT_NET_NO_NET,                 /**< Call is disconnected. */
+  DSI_EVT_PHYSLINK_DOWN_STATE,        /**< Physlink becomes dormant. */
+  DSI_EVT_PHYSLINK_UP_STATE,          /**< Physlink becomes active. */
+  DSI_EVT_NET_RECONFIGURED,           /**< Interface is reconfigured. */
+  DSI_EVT_QOS_STATUS_IND,             /**< A status for the associated QoS has
+                                           changed. */
+  DSI_EVT_NET_NEWADDR,                /**< New address is generated. */
+  DSI_EVT_NET_DELADDR,                /**< An address for the interface has been deleted. */
+  DSI_EVT_NET_PARTIAL_CONN,           /**< Address is available for either IPv4
+                                           or IPv6 only. @newpage */
+  DSI_NET_TMGI_ACTIVATED,
+  DSI_NET_TMGI_DEACTIVATED,
+  DSI_NET_TMGI_ACTIVATED_DEACTIVATED,
+  DSI_NET_TMGI_LIST_CHANGED,
+  DSI_NET_SAI_LIST_CHANGED,
+  DSI_EVT_NET_HANDOFF,
+  DSI_EVT_MAX
+} dsi_net_evt_t;
+
+qmi_idl_service_object_type wds_get_service_object_internal_v01
+ ( int32_t idl_maj_version, int32_t idl_min_version, int32_t library_version );
+
+/** This macro should be used to get the service object */
+#define wds_get_service_object_v01( ) \
+          wds_get_service_object_internal_v01( \
+            LOC_V01_IDL_MAJOR_VERS, LOC_V01_IDL_MINOR_VERS, \
+            LOC_V01_IDL_TOOL_VERS )
+
+/* Structs */
+
+typedef struct wds_get_profile_list_req_msg_v01
+{
+    uint8_t profile_type_valid;
+    uint32_t profile_type;
+} wds_get_profile_list_req_msg_v01;
+
+typedef struct wds_get_profile_settings_req_msg_v01
+{
+    struct {
+        uint32_t profile_type;
+        uint8_t profile_index;
+    } profile;
+} wds_get_profile_settings_req_msg_v01;
+
+typedef struct wds_get_profile_list_resp_msg_v01
+{
+    uint32_t profile_list_len;
+    struct {
+      uint32_t profile_index;
+      uint32_t profile_type;
+    }profile_list[255];
+    qmi_response_type_v01 resp;
+    uint8_t unk1;
+    uint16_t unk2;
+} wds_get_profile_list_resp_msg_v01;
+
+// Only the fields filled in below are accessed by the open source code.
+// The remainder is potentially filled out by library code which we can't access
+// The total size found by reversing is 2016 bytes.
+typedef struct wds_get_profile_settings_resp_msg_v01
+{
+    qmi_response_type_v01 resp;
+    uint8_t profile_name_valid;
+    char profile_name[51];
+    uint8_t pdp_type_valid;
+    uint32_t pdp_type;
+    uint8_t padding1[948]; // Needed for offsets to be correct
+    uint32_t support_emergency_calls_valid;
+    uint32_t support_emergency_calls;
+    // Needed to ensure a sufficiently large struct is allocated.
+    uint8_t padding2[992];
+} wds_get_profile_settings_resp_msg_v01;
+
+typedef struct wds_profile_identifier_type_v01
+{
+    uint32_t profile_type;
+    uint8_t profile_index;
+} wds_profile_identifier_type_v01;
+
+typedef struct dsi_call_param_value_t
+{
+    uint32_t *buf_val;
+    uint32_t num_val;
+} dsi_call_param_value_t;
+
+typedef void* dsi_hndl_t;
+typedef void dsi_evt_payload_t;
+
+/* Callbacks */
+typedef void (*net_ev_cb_type)(
+    dsi_hndl_t handle, void* user_data,
+    dsi_net_evt_t evt, dsi_evt_payload_t *payload_ptr
+);
+
+/* Functions */
+extern int dsi_init();
+extern int dsi_start_data_call(dsi_hndl_t handle);
+extern int dsi_stop_data_call(dsi_hndl_t handle);
+extern int dsi_set_data_call_param(dsi_hndl_t handle, uint8_t call_info, dsi_call_param_value_t *param_info);
+extern int dsi_rel_data_srvc_hndl(dsi_hndl_t handle);
+extern dsi_hndl_t *dsi_get_data_srvc_hndl(net_ev_cb_type callback, void *cb_data);
+
+#endif /* DSI_NETCTRL_H */

--- a/loc_api/include/qmi_client.h
+++ b/loc_api/include/qmi_client.h
@@ -1,0 +1,75 @@
+#ifndef QMI_CLIENT_H
+#define QMI_CLIENT_H
+
+#include "qmi_idl_lib.h"
+
+extern qmi_client_error_type qmi_client_message_decode(
+    qmi_client_type user_handle,
+    qmi_idl_message_type message_type,
+    unsigned int msg_id,
+    void *ind_buf,
+    unsigned int ind_buf_len,
+    void *indBuffer,
+    size_t indSize
+);
+
+extern qmi_client_error_type qmi_client_get_service_instance(
+    qmi_idl_service_object_type service_object,
+    int instanceId,
+    qmi_service_info *serviceInfo
+);
+
+extern qmi_client_error_type qmi_client_get_any_service(
+    qmi_idl_service_object_type service_object,
+    qmi_service_info *serviceInfo
+);
+
+typedef void (*locClientIndCbType)(
+    qmi_client_type user_handle,
+    unsigned int msg_id,
+    void *ind_buf,
+    unsigned int ind_buf_len,
+    void *ind_cb_data
+);
+
+extern qmi_client_error_type qmi_client_init(
+    qmi_service_info *serviceInfo,
+    qmi_idl_service_object_type service_object,
+    locClientIndCbType init_callback,
+    void *cb_data,
+    void * unknown,
+    qmi_client_type *client
+);
+
+typedef void (*qmi_client_error_cb_type)(
+    qmi_client_type user_handle,
+    qmi_client_error_type error,
+    void *err_cb_data
+);
+
+extern qmi_client_error_type qmi_client_register_error_cb(
+    qmi_client_type user_handle,
+    qmi_client_error_cb_type error_cb,
+    void *cb_data
+);
+
+extern qmi_client_error_type qmi_client_get_service_list(
+    qmi_idl_service_object_type ds_client,
+    qmi_service_info *service_info,
+    uint32_t *num_entries,
+    uint32_t *num_services
+);
+
+extern qmi_client_error_type qmi_client_send_msg_sync(
+    qmi_client_type client_handle,
+    uint32_t req_id,
+    void *list_req,
+    uint32_t req_len,
+    void* list_resp,
+    uint32_t resp_len,
+    uint32_t timeout
+);
+
+extern int qmi_client_release ();
+
+#endif /* QMI_CLIENT_H */

--- a/loc_api/include/qmi_idl_lib.h
+++ b/loc_api/include/qmi_idl_lib.h
@@ -1,0 +1,141 @@
+#ifndef QMI_IDL_LIB_H
+#define QMI_IDL_LIB_H
+
+#include <limits.h>
+
+enum qmi_result_type_v01 {
+        /* To force a 32 bit signed enum. Do not change or use*/
+        QMI_RESULT_TYPE_MIN_ENUM_VAL_V01 = INT_MIN,
+        QMI_RESULT_SUCCESS_V01 = 0,
+        QMI_RESULT_FAILURE_V01 = 1,
+        QMI_RESULT_TYPE_MAX_ENUM_VAL_V01 = INT_MAX,
+};
+
+enum qmi_error_type_v01 {
+        /* To force a 32 bit signed enum. Do not change or use*/
+        QMI_ERR_TYPE_MIN_ENUM_VAL_V01 = INT_MIN,
+        QMI_ERR_NONE_V01 = 0x0000,
+        QMI_ERR_MALFORMED_MSG_V01 = 0x0001,
+        QMI_ERR_NO_MEMORY_V01 = 0x0002,
+        QMI_ERR_INTERNAL_V01 = 0x0003,
+        QMI_ERR_CLIENT_IDS_EXHAUSTED_V01 = 0x0005,
+        QMI_ERR_DEVICE_IN_USE_V01 = 0x0017,
+        QMI_ERR_INVALID_ID_V01 = 0x0029,
+        QMI_ERR_INVALID_ARG_V01 = 0x0030,
+        QMI_ERR_ENCODING_V01 = 0x003A,
+        QMI_ERR_INCOMPATIBLE_STATE_V01 = 0x005A,
+        QMI_ERR_NOT_SUPPORTED_V01 = 0x005E,
+        QMI_ERR_TYPE_MAX_ENUM_VAL_V01 = INT_MAX,
+};
+
+typedef enum {
+  QMI_IDL_REQUEST = 0,
+  QMI_IDL_RESPONSE,             /**< QMI Response */
+  QMI_IDL_INDICATION,           /**< QMI Indication */
+  QMI_IDL_NUM_MSG_TYPES         /**< Sentinel for error checking */
+} qmi_idl_message_type;
+
+#define QMI_IDL_FLAGS_OFFSET_IS_16    0x80
+#define QMI_IDL_FLAGS_IS_ARRAY        0x40
+#define QMI_IDL_FLAGS_SZ_IS_16        0x20
+#define QMI_IDL_FLAGS_IS_VARIABLE_LEN 0x10
+#define QMI_IDL_FLAGS_FIRST_EXTENDED  0x08
+#define QMI_IDL_FLAGS_TYPE            0x07
+
+/* Build a 16-bit type field from a type index and a table index */
+#define QMI_IDL_TYPE16(table, type) (((table) << 12) | (type))
+#define QMI_IDL_TYPE88(table, type) (type & 0xFF), (((type & 0xFF00) >> 4) | table)
+
+
+#define QMI_IDL_OFFSET8(t,f)          ((uint8_t) offsetof(t,f))
+#define QMI_IDL_OFFSET16RELATIVE(t,f) offsetof(t,f)
+#define QMI_IDL_OFFSET16ARRAY(t,f)    ((uint8_t) offsetof(t,f)), \
+                                      ((uint8_t) (offsetof(t,f) >> 8))
+#define QMI_IDL_OFFSET32ARRAY(t,f)    ((uint8_t) offsetof(t,f)), \
+                                      ((uint8_t) (offsetof(t,f) >> 8)), \
+                                      ((uint8_t) (offsetof(t,f) >> 16))
+
+#define QMI_IDL_FLAG_END_VALUE 0x20
+
+#define QMI_IDL_TLV_FLAGS_LAST_TLV              0x80
+#define QMI_IDL_TLV_FLAGS_OPTIONAL              0x40
+
+#define QMI_IDL_GENERIC_1_BYTE     0
+#define QMI_IDL_GENERIC_2_BYTE     1
+#define QMI_IDL_GENERIC_4_BYTE     2
+#define QMI_IDL_GENERIC_8_BYTE     3
+#define QMI_IDL_1_BYTE_ENUM        4
+#define QMI_IDL_2_BYTE_ENUM        5
+#define QMI_IDL_STRING             6
+#define QMI_IDL_AGGREGATE          7
+
+#define QMI_NO_ERR 0
+#define QMI_SERVICE_ERR -2
+
+typedef int qmi_client_error_type;
+
+typedef struct {
+    unsigned int info[5];
+} qmi_service_info;
+
+typedef void * qmi_idl_service_object_type;
+
+typedef struct qmi_response_type_v01 {
+    enum qmi_result_type_v01 result;
+    enum qmi_error_type_v01 error;
+} qmi_response_type_v01;
+
+typedef struct qmi_get_supported_msgs_resp_v01 {
+    uint8_t supported_msgs_valid;
+    uint32_t supported_msgs_len;
+    uint8_t supported_msgs[8192];
+} qmi_get_supported_msgs_resp_v01;
+
+typedef struct {
+    uint32_t size;
+    const uint8_t *data;
+} qmi_idl_type_table_entry;
+
+typedef struct {
+    uint32_t size;
+    const uint8_t *data;
+} qmi_idl_message_table_entry;
+
+typedef struct {
+    uint16_t msg_id;
+    uint16_t table_id;
+    uint16_t msg_len;
+} qmi_idl_service_message_table_entry;
+
+// Forward declaration
+struct qmi_idl_type_table_object;
+
+typedef struct qmi_idl_service_object {
+    uint32_t unk1;
+    uint32_t unk2;
+    uint32_t unk3;
+    uint32_t unk4;
+    uint16_t num_messages[QMI_IDL_NUM_MSG_TYPES];
+    const qmi_idl_message_table_entry *message_table[QMI_IDL_NUM_MSG_TYPES];
+    const struct qmi_idl_type_table_object *type_table;
+    uint32_t unk5;
+    struct qmi_idl_service_object *parent;
+} qmi_idl_service_object;
+
+typedef struct qmi_idl_type_table_object {
+    uint16_t num_types;
+    uint16_t num_messages;
+    uint8_t num_tables;
+    const qmi_idl_type_table_entry *type_table;
+    const qmi_idl_message_table_entry *message_table;
+    const struct qmi_idl_type_table_object **type_table_object;
+    const void *unk1;
+} qmi_idl_type_table_object;
+
+// Opague pointer allocated and used by external library
+typedef void* qmi_client_type;
+
+// Provided by qcom library
+extern const qmi_idl_type_table_object common_qmi_idl_type_table_object_v01;
+
+#endif /* QMI_IDL_LIB_H */

--- a/loc_api/loc_api_v02/loc_api_v02_client.c
+++ b/loc_api/loc_api_v02/loc_api_v02_client.c
@@ -1981,14 +1981,8 @@ static locClientStatusEnumType locClientQmiCtrlPointInit(
     locClientCallbackDataType *pLocClientCbData,
     int instanceId)
 {
-  qmi_client_type clnt, notifier;
-  bool notifierInitFlag = false;
+  qmi_client_type clnt;
   locClientStatusEnumType status = eLOC_CLIENT_SUCCESS;
-  // os_params must stay in the same scope as notifier
-  // because when notifier is initialized, the pointer
-  // of os_params is retained in QMI framework, and it
-  // used when notifier is released.
-  qmi_client_os_params os_params;
   // instances of this service
   qmi_service_info serviceInfo;
 
@@ -2009,20 +2003,7 @@ static locClientStatusEnumType locClientQmiCtrlPointInit(
        break;
     }
 
-    // register for service notification
-    rc = qmi_client_notifier_init(locClientServiceObject, &os_params, &notifier);
-    notifierInitFlag = (NULL != notifier);
-
-    if (rc != QMI_NO_ERR) {
-        LOC_LOGE("%s:%d]: qmi_client_notifier_init failed %d\n",
-                 __func__, __LINE__, rc);
-        status = eLOC_CLIENT_FAILURE_INTERNAL;
-        break;
-    }
-
     while (1) {
-        QMI_CCI_OS_SIGNAL_CLEAR(&os_params);
-
         if (instanceId >= 0) {
             // use instance-specific lookup
             rc = qmi_client_get_service_instance(locClientServiceObject, instanceId, &serviceInfo);
@@ -2036,8 +2017,6 @@ static locClientStatusEnumType locClientQmiCtrlPointInit(
 
         if(rc == QMI_NO_ERR)
             break;
-
-        QMI_CCI_OS_SIGNAL_WAIT(&os_params, 0);
     }
 
     LOC_LOGV("%s:%d]: passing the pointer %p to qmi_client_init \n",
@@ -2084,12 +2063,6 @@ static locClientStatusEnumType locClientQmiCtrlPointInit(
     status = eLOC_CLIENT_SUCCESS;
 
   } while(0);
-
-  /* release the notifier handle */
-  if(true == notifierInitFlag)
-  {
-    qmi_client_release(notifier);
-  }
 
   return status;
 }


### PR DESCRIPTION
Headers are created by studying the code and
the functions defined in the kernel headers

Some values used by code that's never used has been put as dummy values.