### PR TITLE
location: add build guard for sony devices

### DIFF
--- a/loc_api/Android.mk
+++ b/loc_api/Android.mk
@@ -1,3 +1,5 @@
+ifneq ($(filter yukon rhine shinano kanuti kitakami loire tone,$(PRODUCT_PLATFORM)),)
+
 ifneq ($(BOARD_VENDOR_QCOM_GPS_LOC_API_HARDWARE),)
 
 LOCAL_PATH := $(call my-dir)
@@ -20,3 +22,5 @@ include $(call all-subdir-makefiles)
 endif #is-board-platform-in-list
 
 endif#BOARD_VENDOR_QCOM_GPS_LOC_API_HARDWARE
+
+endif


### PR DESCRIPTION
to prevent in future errors in build on custom roms

Signed-off-by: David Viteri <davidteri91@gmail.com>