### PR TITLE
qcom: location: loc_api_v02: Add liblog as shared library dependency

### DIFF
--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -25,7 +25,8 @@ LOCAL_SHARED_LIBRARIES := \
     libqmi_common_so \
     libloc_core \
     libgps.utils \
-    libloc_ds_api
+    libloc_ds_api \
+    liblog
 
 LOCAL_SRC_FILES = \
     LocApiV02.cpp \


### PR DESCRIPTION
fixes

hardware/qcom/location/loc_api/loc_api_v02/LocApiV02.cpp:81: error: undefined reference to '__android_log_print'
hardware/qcom/location/loc_api/loc_api_v02/LocApiV02.cpp:81: error: undefined reference to '__android_log_print'
hardware/qcom/location/loc_api/loc_api_v02/LocApiV02.cpp:85: error: undefined reference to '__android_log_print'
hardware/qcom/location/loc_api/loc_api_v02/LocApiV02.cpp:91: error: undefined reference to '__android_log_print'

Signed-off-by: David Viteri <davidteri91@gmail.com>