### PR TITLE
qcom: location: ds_api: Add liblog as shared library dependency

### DIFF
--- a/loc_api/ds_api/Android.mk
+++ b/loc_api/ds_api/Android.mk
@@ -16,8 +16,8 @@ LOCAL_SHARED_LIBRARIES := \
     libqmi_common_so \
     libgps.utils \
     libdsi_netctrl \
-    libqmiservices
-
+    libqmiservices \
+    liblog
 
 LOCAL_SRC_FILES += \
     ds_client.c


### PR DESCRIPTION
fixes

hardware/qcom/location/loc_api/ds_api/ds_client.c:108: error: undefined reference to '__android_log_print'
hardware/qcom/location/loc_api/ds_api/ds_client.c:114: error: undefined reference to '__android_log_print'
hardware/qcom/location/loc_api/ds_api/ds_client.c:122: error: undefined reference to '__android_log_print'
hardware/qcom/location/loc_api/ds_api/ds_client.c:129: error: undefined reference to '__android_log_print'

Signed-off-by: David Viteri <davidteri91@gmail.com>