### PR TITLE
Deblobify

### DIFF
--- a/loc_api/ds_api/Android.mk
+++ b/loc_api/ds_api/Android.mk
@@ -12,7 +12,8 @@ LOCAL_SHARED_LIBRARIES := \
     libutils \
     libcutils \
     libgps.utils \
-    liblog
+    liblog \
+    libloc_loader
 
 LOCAL_SRC_FILES += \
     ds_client.c

--- a/loc_api/ds_api/Android.mk
+++ b/loc_api/ds_api/Android.mk
@@ -11,12 +11,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_SHARED_LIBRARIES := \
     libutils \
     libcutils \
-    libqmi_cci \
-    libqmi_csi \
-    libqmi_common_so \
     libgps.utils \
-    libdsi_netctrl \
-    libqmiservices \
     liblog
 
 LOCAL_SRC_FILES += \

--- a/loc_api/ds_api/ds_client.c
+++ b/loc_api/ds_api/ds_client.c
@@ -37,6 +37,7 @@
 #include <utils/Log.h>
 #include <log_util.h>
 #include <loc_log.h>
+#include <libloc_loader/libloc_loader.h>
 #include "../include/qmi_client.h"
 #include "../include/qmi_idl_lib.h"
 #include "../include/dsi_netctrl.h"
@@ -151,6 +152,9 @@ ds_client_qmi_ctrl_point_init(qmi_client_type *p_wds_qmi_client)
     int timeout = 0;
 
     LOC_LOGD("%s:%d]:Enter\n", __func__, __LINE__);
+
+    // load proprietary symbols from their respective libs
+    load_proprietary_symbols();
 
     //Get service object for QMI_WDS service
     qmi_idl_service_object_type ds_client_service_object =

--- a/loc_api/include/dsi_netctrl.h
+++ b/loc_api/include/dsi_netctrl.h
@@ -53,7 +53,7 @@ typedef enum
   DSI_EVT_MAX
 } dsi_net_evt_t;
 
-qmi_idl_service_object_type wds_get_service_object_internal_v01
+qmi_idl_service_object_type (*wds_get_service_object_internal_v01)
  ( int32_t idl_maj_version, int32_t idl_min_version, int32_t library_version );
 
 /** This macro should be used to get the service object */
@@ -129,11 +129,11 @@ typedef void (*net_ev_cb_type)(
 );
 
 /* Functions */
-extern int dsi_init();
-extern int dsi_start_data_call(dsi_hndl_t handle);
-extern int dsi_stop_data_call(dsi_hndl_t handle);
-extern int dsi_set_data_call_param(dsi_hndl_t handle, uint8_t call_info, dsi_call_param_value_t *param_info);
-extern int dsi_rel_data_srvc_hndl(dsi_hndl_t handle);
-extern dsi_hndl_t *dsi_get_data_srvc_hndl(net_ev_cb_type callback, void *cb_data);
+int (*dsi_init)();
+int (*dsi_start_data_call)(dsi_hndl_t handle);
+int (*dsi_stop_data_call)(dsi_hndl_t handle);
+int (*dsi_set_data_call_param)(dsi_hndl_t handle, uint8_t call_info, dsi_call_param_value_t *param_info);
+int (*dsi_rel_data_srvc_hndl)(dsi_hndl_t handle);
+dsi_hndl_t (*dsi_get_data_srvc_hndl)(net_ev_cb_type callback, void *cb_data);
 
 #endif /* DSI_NETCTRL_H */

--- a/loc_api/include/qmi_client.h
+++ b/loc_api/include/qmi_client.h
@@ -3,7 +3,7 @@
 
 #include "qmi_idl_lib.h"
 
-extern qmi_client_error_type qmi_client_message_decode(
+qmi_client_error_type (*qmi_client_message_decode)(
     qmi_client_type user_handle,
     qmi_idl_message_type message_type,
     unsigned int msg_id,
@@ -13,13 +13,13 @@ extern qmi_client_error_type qmi_client_message_decode(
     size_t indSize
 );
 
-extern qmi_client_error_type qmi_client_get_service_instance(
+qmi_client_error_type (*qmi_client_get_service_instance)(
     qmi_idl_service_object_type service_object,
     int instanceId,
     qmi_service_info *serviceInfo
 );
 
-extern qmi_client_error_type qmi_client_get_any_service(
+qmi_client_error_type (*qmi_client_get_any_service)(
     qmi_idl_service_object_type service_object,
     qmi_service_info *serviceInfo
 );
@@ -32,7 +32,7 @@ typedef void (*locClientIndCbType)(
     void *ind_cb_data
 );
 
-extern qmi_client_error_type qmi_client_init(
+qmi_client_error_type (*qmi_client_init)(
     qmi_service_info *serviceInfo,
     qmi_idl_service_object_type service_object,
     locClientIndCbType init_callback,
@@ -47,20 +47,20 @@ typedef void (*qmi_client_error_cb_type)(
     void *err_cb_data
 );
 
-extern qmi_client_error_type qmi_client_register_error_cb(
+qmi_client_error_type (*qmi_client_register_error_cb)(
     qmi_client_type user_handle,
     qmi_client_error_cb_type error_cb,
     void *cb_data
 );
 
-extern qmi_client_error_type qmi_client_get_service_list(
+qmi_client_error_type (*qmi_client_get_service_list)(
     qmi_idl_service_object_type ds_client,
     qmi_service_info *service_info,
     uint32_t *num_entries,
     uint32_t *num_services
 );
 
-extern qmi_client_error_type qmi_client_send_msg_sync(
+qmi_client_error_type (*qmi_client_send_msg_sync)(
     qmi_client_type client_handle,
     uint32_t req_id,
     void *list_req,
@@ -70,6 +70,6 @@ extern qmi_client_error_type qmi_client_send_msg_sync(
     uint32_t timeout
 );
 
-extern int qmi_client_release ();
+int (*qmi_client_release) ();
 
 #endif /* QMI_CLIENT_H */

--- a/loc_api/include/qmi_idl_lib.h
+++ b/loc_api/include/qmi_idl_lib.h
@@ -136,6 +136,6 @@ typedef struct qmi_idl_type_table_object {
 typedef void* qmi_client_type;
 
 // Provided by qcom library
-extern const qmi_idl_type_table_object common_qmi_idl_type_table_object_v01;
+qmi_idl_type_table_object common_qmi_idl_type_table_object_v01;
 
 #endif /* QMI_IDL_LIB_H */

--- a/loc_api/libloc_loader/Android.mk
+++ b/loc_api/libloc_loader/Android.mk
@@ -1,0 +1,26 @@
+ifneq ($(BUILD_TINY_ANDROID),true)
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libloc_loader
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SHARED_LIBRARIES := \
+    liblog
+
+LOCAL_SRC_FILES += \
+    libloc_loader.c
+
+LOCAL_COPY_HEADERS_TO:= libloc_loader/
+
+LOCAL_COPY_HEADERS:= \
+    libloc_loader.h
+
+LOCAL_PROPRIETARY_MODULE := true
+
+include $(BUILD_SHARED_LIBRARY)
+
+endif # not BUILD_TINY_ANDROID

--- a/loc_api/libloc_loader/libloc_loader.c
+++ b/loc_api/libloc_loader/libloc_loader.c
@@ -1,0 +1,66 @@
+#include <dlfcn.h>
+#include <cutils/log.h>
+
+#include "../include/qmi_client.h"
+#include "../include/qmi_idl_lib.h"
+#include "../include/dsi_netctrl.h"
+#include "libloc_loader.h"
+
+#define LOG_TAG "LIBLOC_LOADER"
+
+void *lib_handle = NULL;
+
+void load_from_libdsi_netctrl() {
+    lib_handle = dlopen(LIBDSI_NETCTRL, RTLD_NOW);
+    if (!lib_handle) {
+        ALOGE("%s: DLOPEN failed for %s", __func__, LIBDSI_NETCTRL);
+    } else {
+        dsi_init = dlsym(lib_handle, "dsi_init");
+        dsi_start_data_call = dlsym(lib_handle, "dsi_start_data_call");
+        dsi_stop_data_call = dlsym(lib_handle, "dsi_stop_data_call");
+        dsi_set_data_call_param = dlsym(lib_handle, "dsi_set_data_call_param");
+        dsi_rel_data_srvc_hndl = dlsym(lib_handle, "dsi_rel_data_srvc_hndl");
+        dsi_get_data_srvc_hndl = dlsym(lib_handle, "dsi_get_data_srvc_hndl");
+    }
+}
+
+void load_from_libqmi_cci() {
+    lib_handle = dlopen(LIBQMI_CCI, RTLD_NOW);
+    if (!lib_handle) {
+        ALOGE("%s: DLOPEN failed for %s", __func__, LIBQMI_CCI);
+    } else {
+        qmi_client_message_decode = dlsym(lib_handle, "qmi_client_message_decode");
+        qmi_client_get_service_instance = dlsym(lib_handle, "qmi_client_get_service_instance");
+        qmi_client_get_any_service = dlsym(lib_handle, "qmi_client_get_any_service");
+        qmi_client_init = dlsym(lib_handle, "qmi_client_init");
+        qmi_client_register_error_cb = dlsym(lib_handle, "qmi_client_register_error_cb");
+        qmi_client_get_service_list = dlsym(lib_handle, "qmi_client_get_service_list");
+        qmi_client_send_msg_sync = dlsym(lib_handle, "qmi_client_send_msg_sync");
+        qmi_client_release = dlsym(lib_handle, "qmi_client_release");
+    }
+}
+
+void load_from_libqmi_common_so() {
+    lib_handle = dlopen(LIBQMI_COMMON_SO, RTLD_NOW);
+    if (!lib_handle) {
+        ALOGE("%s: DLOPEN failed for %s", __func__, LIBQMI_COMMON_SO);
+    } else {
+        common_qmi_idl_type_table_object_v01 = *(qmi_idl_type_table_object*) dlsym(lib_handle, "common_qmi_idl_type_table_object_v01");
+    }
+}
+
+void load_from_libqmiservices() {
+    lib_handle = dlopen(LIBQMISERVICES, RTLD_NOW);
+    if (!lib_handle) {
+        ALOGE("%s: DLOPEN failed for %s", __func__, LIBQMISERVICES);
+    } else {
+        wds_get_service_object_internal_v01 = dlsym(lib_handle, "wds_get_service_object_internal_v01");
+    }
+}
+
+void load_proprietary_symbols() {
+   load_from_libdsi_netctrl();
+   load_from_libqmi_cci();
+   load_from_libqmi_common_so();
+   load_from_libqmiservices();
+}

--- a/loc_api/libloc_loader/libloc_loader.h
+++ b/loc_api/libloc_loader/libloc_loader.h
@@ -1,0 +1,11 @@
+#ifndef LIBLOC_LOADER_H
+#define LIBLOC_LOADER_H
+
+#define LIBDSI_NETCTRL "libdsi_netctrl.so"
+#define LIBQMI_CCI "libqmi_cci.so"
+#define LIBQMI_COMMON_SO "libqmi_common_so.so"
+#define LIBQMISERVICES "libqmiservices.so"
+
+void load_proprietary_symbols();
+
+#endif

--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -20,9 +20,6 @@ endif
 LOCAL_SHARED_LIBRARIES := \
     libutils \
     libcutils \
-    libqmi_cci \
-    libqmi_csi \
-    libqmi_common_so \
     libloc_core \
     libgps.utils \
     libloc_ds_api \

--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -23,7 +23,8 @@ LOCAL_SHARED_LIBRARIES := \
     libloc_core \
     libgps.utils \
     libloc_ds_api \
-    liblog
+    liblog \
+    libloc_loader
 
 LOCAL_SRC_FILES = \
     LocApiV02.cpp \

--- a/loc_api/loc_api_v02/LocApiV02.cpp
+++ b/loc_api/loc_api_v02/LocApiV02.cpp
@@ -46,6 +46,10 @@
 #include <gps_extended.h>
 #include "platform_lib_includes.h"
 
+extern "C" {
+#include <libloc_loader/libloc_loader.h>
+}
+
 using namespace loc_core;
 
 /* Default session id ; TBD needs incrementing for each */
@@ -188,6 +192,10 @@ LocApiV02 :: open(LOC_API_ADAPTER_EVENT_MASK_T mask)
   locClientEventMaskType qmiMask = convertMask(newMask);
   LOC_LOGD("%s:%d]: Enter mMask: %x; mask: %x; newMask: %x mQmiMask: %lu qmiMask: %lu",
            __func__, __LINE__, mMask, mask, newMask, mQmiMask, qmiMask);
+
+  // load proprietary symbols from their respective libs
+  load_proprietary_symbols();
+
   /* If the client is already open close it first */
   if(LOC_CLIENT_INVALID_HANDLE_VALUE == clientHandle)
   {


### PR DESCRIPTION
After the switch to /odm, proprietary location modules required by their oss counterparts aren't found for static linking.
The solution proposed here is a dynamic loading module (libloc_loader), that will take care of the proprietary symbols that are missing at build time, and try to link them at runtime.