### PR TITLE
[NEEDSTESTING] Android.mk: move build guard up a level

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,3 @@
+ifneq ($(filter yukon rhine shinano kanuti kitakami loire tone yoshino,$(PRODUCT_PLATFORM)),)
+include $(call all-subdir-makefiles)
+endif

--- a/loc_api/Android.mk
+++ b/loc_api/Android.mk
@@ -1,5 +1,3 @@
-ifneq ($(filter yukon rhine shinano kanuti kitakami loire tone yoshino,$(PRODUCT_PLATFORM)),)
-
 ifneq ($(BOARD_VENDOR_QCOM_GPS_LOC_API_HARDWARE),)
 
 LOCAL_PATH := $(call my-dir)
@@ -50,5 +48,3 @@ $(shell ln -sf /firmware/image/gss.mdt $(TARGET_OUT_ETC)/firmware/gss.mdt)
 endif
 
 endif#BOARD_VENDOR_QCOM_GPS_LOC_API_HARDWARE
-
-endif


### PR DESCRIPTION
Only loc_api had the guard before, so other modules like gnsspp were not protected.
This caused issues for non-sony devices built in the same environment.
This change applies the guard for all modules.

Change-Id: I17c97fc6c2f125f47a1c5ea212f831a1526303a6