### PR TITLE
loc_api: include: Correct pointer type of message_table

### DIFF
--- a/loc_api/include/qmi_idl_lib.h
+++ b/loc_api/include/qmi_idl_lib.h
@@ -116,7 +116,7 @@ typedef struct qmi_idl_service_object {
     uint32_t unk3;
     uint32_t unk4;
     uint16_t num_messages[QMI_IDL_NUM_MSG_TYPES];
-    const qmi_idl_message_table_entry *message_table[QMI_IDL_NUM_MSG_TYPES];
+    const qmi_idl_service_message_table_entry *message_table[QMI_IDL_NUM_MSG_TYPES];
     const struct qmi_idl_type_table_object *type_table;
     uint32_t unk5;
     struct qmi_idl_service_object *parent;


### PR DESCRIPTION
location_service_v02 populates the table with pointers of type qmi_idl_service_message_table_entry
Make sure the header declares the same type to avoid a compiler warning about incompatible pointer types