### PR TITLE
location: Replace unused GNSS-CFLAGS with proper content

### DIFF
--- a/gnsspps/Android.mk
+++ b/gnsspps/Android.mk
@@ -27,7 +27,25 @@ LOCAL_C_INCLUDES := \
     $(TARGET_OUT_HEADERS)/gps.utils \
     $(TARGET_OUT_HEADERS)/libloc_pla
 
-LOCAL_CFLAGS += $(GNSS_CFLAGS)
+LOCAL_CFLAGS += \
+    -Werror \
+    -Wno-error=unused-parameter \
+    -Wno-error=format \
+    -Wno-error=macro-redefined \
+    -Wno-error=reorder \
+    -Wno-error=missing-braces \
+    -Wno-error=self-assign \
+    -Wno-error=enum-conversion \
+    -Wno-error=logical-op-parentheses \
+    -Wno-error=null-arithmetic \
+    -Wno-error=null-conversion \
+    -Wno-error=parentheses-equality \
+    -Wno-error=undefined-bool-conversion \
+    -Wno-error=tautological-compare \
+    -Wno-error=switch \
+    -Wno-error=date-time \
+    -Wno-error=incompatible-pointer-types
+
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)

--- a/loc_api/ds_api/Android.mk
+++ b/loc_api/ds_api/Android.mk
@@ -36,7 +36,25 @@ LOCAL_C_INCLUDES := \
     $(TARGET_OUT_HEADERS)/gps.utils \
     $(TARGET_OUT_HEADERS)/libloc_pla
 
-LOCAL_CFLAGS += $(GNSS_CFLAGS)
+LOCAL_CFLAGS += \
+    -Werror \
+    -Wno-error=unused-parameter \
+    -Wno-error=format \
+    -Wno-error=macro-redefined \
+    -Wno-error=reorder \
+    -Wno-error=missing-braces \
+    -Wno-error=self-assign \
+    -Wno-error=enum-conversion \
+    -Wno-error=logical-op-parentheses \
+    -Wno-error=null-arithmetic \
+    -Wno-error=null-conversion \
+    -Wno-error=parentheses-equality \
+    -Wno-error=undefined-bool-conversion \
+    -Wno-error=tautological-compare \
+    -Wno-error=switch \
+    -Wno-error=date-time \
+    -Wno-error=incompatible-pointer-types
+
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)

--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -45,7 +45,25 @@ LOCAL_C_INCLUDES := \
     $(TARGET_OUT_HEADERS)/libloc_pla \
     $(TARGET_OUT_HEADERS)/liblocation_api
 
-LOCAL_CFLAGS += $(GNSS_CFLAGS)
+LOCAL_CFLAGS += \
+    -Werror \
+    -Wno-error=unused-parameter \
+    -Wno-error=format \
+    -Wno-error=macro-redefined \
+    -Wno-error=reorder \
+    -Wno-error=missing-braces \
+    -Wno-error=self-assign \
+    -Wno-error=enum-conversion \
+    -Wno-error=logical-op-parentheses \
+    -Wno-error=null-arithmetic \
+    -Wno-error=null-conversion \
+    -Wno-error=parentheses-equality \
+    -Wno-error=undefined-bool-conversion \
+    -Wno-error=tautological-compare \
+    -Wno-error=switch \
+    -Wno-error=date-time \
+    -Wno-error=incompatible-pointer-types
+
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)


### PR DESCRIPTION
make clang happy (vndk rules)

Change-Id: I8cbad1af84054c5d999d4e06f3e4171775c47946
Signed-off-by: Humberto Borba <humberos@omnirom.org>