### PR TITLE
loc_api: Cleanup LOG_TAG macro redefined warning, fix unused variable warnings.

### DIFF
--- a/loc_api/ds_api/Android.mk
+++ b/loc_api/ds_api/Android.mk
@@ -28,7 +28,6 @@ LOCAL_COPY_HEADERS:= \
     ds_client.h
 
 LOCAL_LDFLAGS += -Wl,--export-dynamic
-LOCAL_CFLAGS += -Wno-macro-redefined
 
 ## Includes
 LOCAL_C_INCLUDES := \

--- a/loc_api/ds_api/ds_client.c
+++ b/loc_api/ds_api/ds_client.c
@@ -108,7 +108,6 @@ static void net_ev_cb
   dsi_evt_payload_t *payload_ptr
 )
 {
-    int i;
     (void)handle;
     (void)user_data;
     (void)payload_ptr;

--- a/loc_api/libloc_loader/Android.mk
+++ b/loc_api/libloc_loader/Android.mk
@@ -14,8 +14,6 @@ LOCAL_SHARED_LIBRARIES := \
 LOCAL_SRC_FILES += \
     libloc_loader.c
 
-LOCAL_CFLAGS += -Wno-macro-redefined
-
 LOCAL_HEADER_LIBRARIES := libcutils_headers libutils_headers
 
 LOCAL_COPY_HEADERS_TO:= libloc_loader/

--- a/loc_api/libloc_loader/libloc_loader.c
+++ b/loc_api/libloc_loader/libloc_loader.c
@@ -1,12 +1,13 @@
 #include <dlfcn.h>
+
+#define LOG_TAG "LIBLOC_LOADER"
+
 #include <log/log.h>
 
 #include "../include/qmi_client.h"
 #include "../include/qmi_idl_lib.h"
 #include "../include/dsi_netctrl.h"
 #include "libloc_loader.h"
-
-#define LOG_TAG "LIBLOC_LOADER"
 
 void *lib_handle = NULL;
 

--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -33,7 +33,6 @@ LOCAL_SRC_FILES = \
     location_service_v02.c
 
 LOCAL_CFLAGS += \
-    -Wno-macro-redefined \
     -fno-short-enums \
     -D_ANDROID_
 

--- a/loc_api/loc_api_v02/LocApiV02.cpp
+++ b/loc_api/loc_api_v02/LocApiV02.cpp
@@ -2629,9 +2629,6 @@ void  LocApiV02 :: reportSvMeasurement (
 
   if(1 == gnss_raw_measurement_ptr->rcvrClockFrequencyInfo_valid)
   {
-    qmiLocRcvrClockFrequencyInfoStructT_v02* rcvClockFreqInfo =
-      (qmiLocRcvrClockFrequencyInfoStructT_v02*) &gnss_raw_measurement_ptr->rcvrClockFrequencyInfo;
-
     svMeasurementSet.clockFreq.size         = sizeof(Gnss_LocRcvrClockFrequencyInfoStructType);
     svMeasurementSet.clockFreqValid         = gnss_raw_measurement_ptr->rcvrClockFrequencyInfo_valid;
     svMeasurementSet.clockFreq.clockDrift   =
@@ -2649,9 +2646,6 @@ void  LocApiV02 :: reportSvMeasurement (
   if((1 == gnss_raw_measurement_ptr->leapSecondInfo_valid) &&
      (0 == gnss_raw_measurement_ptr->leapSecondInfo.leapSecUnc) )
   {
-    qmiLocLeapSecondInfoStructT_v02* leapSecond =
-      (qmiLocLeapSecondInfoStructT_v02*)&gnss_raw_measurement_ptr->leapSecondInfo;
-
     svMeasurementSet.leapSec.size       = sizeof(Gnss_LeapSecondInfoStructType);
     svMeasurementSet.leapSecValid       = (bool)gnss_raw_measurement_ptr->leapSecondInfo_valid;
     svMeasurementSet.leapSec.leapSec    = gnss_raw_measurement_ptr->leapSecondInfo.leapSec;
@@ -3301,9 +3295,6 @@ void LocApiV02 :: reportNiRequest(
     // ES SUPL
     if(ni_req_ptr->suplEmergencyNotification_valid ==1)
     {
-        const qmiLocEmergencyNotificationStructT_v02 *supl_emergency_request =
-        &ni_req_ptr->suplEmergencyNotification;
-
         notif.type = GNSS_NI_TYPE_EMERGENCY_SUPL;
     }
 
@@ -4414,7 +4405,6 @@ LocApiV02 :: setGpsLock(GnssConfigGpsLock lock)
 */
 int LocApiV02 :: getGpsLock()
 {
-    qmiLocGetEngineLockReqMsgT_v02 getEngineLockReq;
     qmiLocGetEngineLockIndMsgT_v02 getEngineLockInd;
     locClientStatusEnumType status;
     locClientReqUnionType req_union;


### PR DESCRIPTION
Tested with `mmm vendor/qcom/opensource/location/`.