### PR TITLE
[DONOTMERGE][Q-COMPAT] loc_api: Fix: Use lu in log format

### DIFF
--- a/loc_api/loc_api_v02/LocApiV02.cpp
+++ b/loc_api/loc_api_v02/LocApiV02.cpp
@@ -2083,7 +2083,7 @@ locClientEventMaskType LocApiV02 :: convertMask(
   LOC_API_ADAPTER_EVENT_MASK_T mask)
 {
   locClientEventMaskType eventMask = 0;
-  LOC_LOGD("%s:%d]: adapter mask = %u\n", __func__, __LINE__, mask);
+  LOC_LOGD("%s:%d]: adapter mask = %lu\n", __func__, __LINE__, mask);
 
   if (mask & LOC_API_ADAPTER_BIT_PARSED_POSITION_REPORT)
       eventMask |= QMI_LOC_EVENT_MASK_POSITION_REPORT_V02;


### PR DESCRIPTION
(This commit is meant for the master branch, but since that branch was reset to the wrong commit, PR it here)

LOC_API_ADAPTER_EVENT_MASK_T was changed from 'unsigned int' to 'uint64_t'.
Correct the format specifier used to print LOC_API_ADAPTER_EVENT_MASK_T
to avoid breaking compilation of libgnss.