### PR TITLE
[7.1.r1] loc_api: Cast payload to appropriate enum type for comparison.

### DIFF
--- a/loc_api/loc_api_v02/LocApiV02.cpp
+++ b/loc_api/loc_api_v02/LocApiV02.cpp
@@ -4729,7 +4729,7 @@ locClientStatusEnumType LocApiV02::locSyncSendReq(uint32_t req_id,
             timeout_msec, ind_id, ind_payload_ptr);
     if (eLOC_CLIENT_FAILURE_ENGINE_BUSY == status ||
             (eLOC_CLIENT_SUCCESS == status && nullptr != ind_payload_ptr &&
-            eLOC_CLIENT_FAILURE_ENGINE_BUSY == *((qmiLocStatusEnumT_v02*)ind_payload_ptr))) {
+            eLOC_CLIENT_FAILURE_ENGINE_BUSY == *((locClientStatusEnumType*)ind_payload_ptr))) {
         if (mResenders.empty()) {
             registerEventMask(mQmiMask | QMI_LOC_EVENT_MASK_ENGINE_STATE_V02);
         }


### PR DESCRIPTION
This variable is compared against an enum value of a different type.
Cast the pointer to the right type to address the error.
```
loc_api/loc_api_v02/LocApiV02.cpp:4732:45:
error: comparison of two values with different enumeration types
('locClientStatusEnumType' and 'qmiLocStatusEnumT_v02')
[-Werror,-Wenum-compare]

eLOC_CLIENT_FAILURE_ENGINE_BUSY == *((qmiLocStatusEnumT_v02*)ind_payload_ptr))) {
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```