### PR TITLE
[WIP] loc_api_v02: Add getGpsLock() subType param

### DIFF
--- a/loc_api/loc_api_v02/LocApiV02.cpp
+++ b/loc_api/loc_api_v02/LocApiV02.cpp
@@ -4430,7 +4430,7 @@ LocApiV02 :: setGpsLock(GnssConfigGpsLock lock)
   Current value of GPS Lock on success
   -1 on failure
 */
-int LocApiV02 :: getGpsLock()
+int LocApiV02 :: getGpsLock(uint8_t subType)
 {
     qmiLocGetEngineLockIndMsgT_v02 getEngineLockInd;
     locClientStatusEnumType status;

--- a/loc_api/loc_api_v02/LocApiV02.h
+++ b/loc_api/loc_api_v02/LocApiV02.h
@@ -284,7 +284,7 @@ public:
     Current value of GPS Lock on success
     -1 on failure
   */
-  virtual int getGpsLock(void);
+  virtual int getGpsLock(uint8_t /*subType*/);
   virtual int setSvMeasurementConstellation(const qmiLocGNSSConstellEnumT_v02 svConstellation);
   virtual LocationError setXtraVersionCheck(uint32_t check);
   virtual void installAGpsCert(const LocDerEncodedCertificate* pData,


### PR DESCRIPTION
Matching the change in
f475797d3c031ae97a393fa3e899034836fe7ba6
"Handle updating the carrier configuration"
https://android.googlesource.com/platform/hardware/qcom/sdm845/gps/+/f475797d3c031ae97a393fa3e899034836fe7ba6

Built-tested on kagura

See also: https://source.codeaurora.org/quic/la/platform/vendor/qcom-opensource/location/commit/?h=LA.UM.8.2.r2-00600-sdm660.0&id=32180c7af7847ad2cf3a1a36d5cf234ec93f3fbd