### PR TITLE
[DNM] loc_api: libloc_loader: Headers as module

### DIFF
--- a/loc_api/libloc_loader/Android.mk
+++ b/loc_api/libloc_loader/Android.mk
@@ -3,26 +3,21 @@ ifneq ($(BUILD_TINY_ANDROID),true)
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
-
 LOCAL_MODULE := libloc_loader
-
 LOCAL_MODULE_TAGS := optional
-
 LOCAL_SHARED_LIBRARIES := \
     liblog
-
 LOCAL_SRC_FILES += \
     libloc_loader.c
-
-LOCAL_HEADER_LIBRARIES := libcutils_headers libutils_headers
-
-LOCAL_COPY_HEADERS_TO:= libloc_loader/
-
-LOCAL_COPY_HEADERS:= \
-    libloc_loader.h
-
+LOCAL_HEADER_LIBRARIES := \
+    libcutils_headers \
+    libutils_headers
 LOCAL_PROPRIETARY_MODULE := true
-
 include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libloc_loader_headers
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
+include $(BUILD_HEADER_LIBRARY)
 
 endif # not BUILD_TINY_ANDROID

--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -37,11 +37,13 @@ LOCAL_CFLAGS += \
 LOCAL_C_INCLUDES := \
 
 LOCAL_HEADER_LIBRARIES := \
+    libloc_loader_headers \
     libloc_core_headers \
     libgps.utils_headers \
     libloc_ds_api_headers \
     libloc_pla_headers \
     liblocation_api_headers
+
 LOCAL_CFLAGS += $(GNSS_CFLAGS)
 include $(BUILD_SHARED_LIBRARY)
 

--- a/loc_api/loc_api_v02/LocApiV02.cpp
+++ b/loc_api/loc_api_v02/LocApiV02.cpp
@@ -47,7 +47,7 @@
 #include <LocDualContext.h>
 
 extern "C" {
-#include <libloc_loader/libloc_loader.h>
+#include "libloc_loader.h"
 }
 
 using namespace loc_core;


### PR DESCRIPTION
Move the libloc_loader header into its own module so it can be imported by any module, regardless of path. This saves some relative-path `#include "../libloc_loader.h"` or `LOCAL_COPY_HEADERS_TO` code spaghetti and prepares for Android R and soong where these shenanigans are not allowed
anymore.

@jerpelea could you please set `q-mr0` as the default branch for this repo?