### PR TITLE
Android.mk: Make q-mr0 guard 4.9-only

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,5 +1,5 @@
 ifeq ($(PRODUCT_PLATFORM_SOD),true)
-ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.9 4.14))
+ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.9))
 LOCAL_PATH := $(call my-dir)
 include $(LOCAL_PATH)/build/target_specific_features.mk
 include $(call all-makefiles-under,$(LOCAL_PATH))


### PR DESCRIPTION
The q-mr0 HAL version should now only be used with a 4.9 kernel.

For 4.14, the LA.UM.8.1.r1 OSS location should be used.

See also https://github.com/sonyxperiadev/vendor-qcom-opensource-location/pull/27