### PR TITLE
Android.mk: Make LA.UM.8.1.r1 guard 4.14-only

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,5 +1,5 @@
 ifeq ($(PRODUCT_PLATFORM_SOD),true)
-ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.9 4.14))
+ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.14))
 LOCAL_PATH := $(call my-dir)
 include $(LOCAL_PATH)/build/target_specific_features.mk
 include $(call all-makefiles-under,$(LOCAL_PATH))


### PR DESCRIPTION
An 8.1 HAL should not be used with a 4.9 kernel.

Should you require building for 4.9, use the q-mr1 branch instead.

See also https://github.com/sonyxperiadev/vendor-qcom-opensource-location/pull/26