### PR TITLE
Android.mk: Add 4.19 to the guard allowance

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,5 +1,5 @@
 ifeq ($(PRODUCT_PLATFORM_SOD),true)
-ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.9 4.14))
+ifneq (,$(filter $(strip $(SOMC_KERNEL_VERSION)),4.9 4.14 4.19))
 LOCAL_PATH := $(call my-dir)
 include $(LOCAL_PATH)/build/target_specific_features.mk
 include $(call all-makefiles-under,$(LOCAL_PATH))


### PR DESCRIPTION
Edo platform is using 4.19 kernel and thus needs to be allowed in this guard to build the location HAL.