### PR TITLE
[2.0.r1] Get rid of proprietary libqmi dependency

### DIFF
--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -10,8 +10,6 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_SHARED_LIBRARIES := \
     libutils \
     libcutils \
-    libqmi_cci \
-    libqmi_common_so \
     libloc_core \
     libgps.utils \
     libdl \
@@ -28,17 +26,11 @@ LOCAL_CFLAGS += \
     -fno-short-enums \
     -D_ANDROID_
 
-## Includes
-LOCAL_C_INCLUDES := \
-    $(TARGET_OUT_HEADERS)/qmi-framework/inc
-
 LOCAL_HEADER_LIBRARIES := \
     libloc_core_headers \
     libgps.utils_headers \
     libloc_pla_headers \
-    liblocation_api_headers \
-    libqmi_common_headers \
-    libqmi_cci_headers
+    liblocation_api_headers
 
 LOCAL_CFLAGS += $(GNSS_CFLAGS)
 include $(BUILD_SHARED_LIBRARY)

--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -20,7 +20,8 @@ LOCAL_SRC_FILES := \
     loc_api_v02_log.cpp \
     loc_api_v02_client.cpp \
     loc_api_sync_req.cpp \
-    location_service_v02.c
+    location_service_v02.c \
+    libqmi_loader.cpp
 
 LOCAL_CFLAGS += \
     -fno-short-enums \

--- a/loc_api/loc_api_v02/common_v01.h
+++ b/loc_api/loc_api_v02/common_v01.h
@@ -1,0 +1,34 @@
+#ifndef COMMON_V01_H
+#define COMMON_V01_H
+
+#include "qmi_idl_lib_internal.h"
+
+typedef enum {
+    QMI_RESULT_SUCCESS_V01 = 0,
+    QMI_RESULT_FAILURE_V01 = 1,
+} qmi_result_type_v01;
+
+typedef enum {
+    QMI_ERR_MALFORMED_MSG_V01 = 0x0001,
+    QMI_ERR_DEVICE_IN_USE_V01 = 0x0017,
+    QMI_ERR_INVALID_ARG_V01 = 0x0030,
+    QMI_ERR_INVALID_MESSAGE_ID_V01 = 0x0039,
+    QMI_ERR_SESSION_OWNERSHIP_V01 = 0x0043,
+    QMI_ERR_NOT_SUPPORTED_V01 = 0x005E,
+} qmi_error_type_v01;
+
+typedef struct {
+    qmi_result_type_v01 result;
+    qmi_error_type_v01 error;
+} qmi_response_type_v01;
+
+typedef struct {
+    qmi_response_type_v01 resp;
+    uint8_t supported_msgs_valid;
+    uint32_t supported_msgs_len;
+    uint8_t supported_msgs[8192];
+} qmi_get_supported_msgs_resp_v01;
+
+extern qmi_idl_type_table_object common_qmi_idl_type_table_object_v01;
+
+#endif /* COMMON_V01_H */

--- a/loc_api/loc_api_v02/libqmi_loader.cpp
+++ b/loc_api/loc_api_v02/libqmi_loader.cpp
@@ -1,0 +1,90 @@
+#include <string>
+#include <vector>
+#include <dlfcn.h>
+
+#include "loc_util_log.h"
+#include "common_v01.h"
+#include "qmi_client.h"
+
+#include "libqmi_loader.h"
+
+qmi_client_get_any_service_t qmi_client_get_any_service;
+qmi_client_get_service_instance_t qmi_client_get_service_instance;
+qmi_client_init_t qmi_client_init;
+qmi_client_message_decode_t qmi_client_message_decode;
+qmi_client_notifier_init_t qmi_client_notifier_init;
+qmi_client_register_error_cb_t qmi_client_register_error_cb;
+qmi_client_release_t qmi_client_release;
+qmi_client_send_msg_sync_t qmi_client_send_msg_sync;
+
+qmi_idl_type_table_object common_qmi_idl_type_table_object_v01;
+
+static void *load_library(const char *lib_name) {
+    void *handle = dlopen(lib_name, RTLD_NOW);
+    if (!handle) {
+        LOC_LOGE("%s: ERROR: Failed to load library %s: %s\n", __func__,
+                lib_name, dlerror());
+    }
+    return handle;
+}
+
+static int load_symbols(void *handle,
+            const std::vector<std::pair<std::string, void **>> &symbols) {
+    for (const auto &symbol : symbols) {
+        *symbol.second = dlsym(handle, symbol.first.c_str());
+        if (!*symbol.second) {
+            LOC_LOGE("%s: ERROR: Failed to load symbol %s: %s\n", __func__,
+                    symbol.first.c_str(), dlerror());
+            dlclose(handle);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int load_libqmi_cci_symbols() {
+    void *handle = load_library("libqmi_cci.so");
+    if (!handle) {
+        return -1;
+    }
+
+    std::vector<std::pair<std::string, void **>> symbols = {
+        {"qmi_client_get_any_service", reinterpret_cast<void **>(&qmi_client_get_any_service)},
+        {"qmi_client_get_service_instance", reinterpret_cast<void **>(&qmi_client_get_service_instance)},
+        {"qmi_client_init", reinterpret_cast<void **>(&qmi_client_init)},
+        {"qmi_client_message_decode", reinterpret_cast<void **>(&qmi_client_message_decode)},
+        {"qmi_client_notifier_init", reinterpret_cast<void **>(&qmi_client_notifier_init)},
+        {"qmi_client_register_error_cb", reinterpret_cast<void **>(&qmi_client_register_error_cb)},
+        {"qmi_client_release", reinterpret_cast<void **>(&qmi_client_release)},
+        {"qmi_client_send_msg_sync", reinterpret_cast<void **>(&qmi_client_send_msg_sync)},
+    };
+
+    return load_symbols(handle, symbols);
+}
+
+static int load_libqmi_common_so_symbols() {
+    void *handle = load_library("libqmi_common_so.so");
+    if (!handle) {
+        return -1;
+    }
+
+    common_qmi_idl_type_table_object_v01 = *reinterpret_cast<qmi_idl_type_table_object*>(
+        dlsym(handle, "common_qmi_idl_type_table_object_v01"));
+
+    return 0;
+}
+
+int load_qmi_symbols() {
+    if (load_libqmi_cci_symbols()) {
+        LOC_LOGE("%s: ERROR: One or more symbols failed to load from libqmi_cci.so\n", __func__);
+        return -1;
+    }
+
+    if (load_libqmi_common_so_symbols()) {
+        LOC_LOGE("%s: ERROR: One or more symbols failed to load from libqmi_common_so.so\n", __func__);
+        return -1;
+    }
+
+    return 0;
+}

--- a/loc_api/loc_api_v02/libqmi_loader.h
+++ b/loc_api/loc_api_v02/libqmi_loader.h
@@ -1,0 +1,6 @@
+#ifndef LIBQMI_LOADER_H
+#define LIBQMI_LOADER_H
+
+int load_qmi_symbols();
+
+#endif /* LIBQMI_LOADER_H */

--- a/loc_api/loc_api_v02/loc_api_v02_client.cpp
+++ b/loc_api/loc_api_v02/loc_api_v02_client.cpp
@@ -87,6 +87,8 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "loc_cfg.h"
 
+#include "libqmi_loader.h"
+
 #ifdef LOC_UTIL_TARGET_OFF_TARGET
 
 // timeout in ms before send_msg_sync should return
@@ -2254,6 +2256,12 @@ locClientStatusEnumType locClientOpen (
   int instanceId;
   locClientStatusEnumType status;
   int tries = 1;
+
+  if (load_qmi_symbols()) {
+    LOC_LOGE("%s:%d]: failed to load QMI symbols. Aborting...",
+             __func__, __LINE__);
+    return eLOC_CLIENT_FAILURE_GENERAL;
+  }
 
   if (getEmulatorCfg()) {
       instanceId = eLOC_CLIENT_INSTANCE_ID_MODEM_EMULATOR;

--- a/loc_api/loc_api_v02/qmi_cci_common.h
+++ b/loc_api/loc_api_v02/qmi_cci_common.h
@@ -1,0 +1,6 @@
+#ifndef QMI_CCI_COMMON_H
+#define QMI_CCI_COMMON_H
+
+/* Stub header */
+
+#endif /* QMI_CCI_COMMON_H */

--- a/loc_api/loc_api_v02/qmi_cci_target.h
+++ b/loc_api/loc_api_v02/qmi_cci_target.h
@@ -1,0 +1,6 @@
+#ifndef QMI_CCI_TARGET_H
+#define QMI_CCI_TARGET_H
+
+/* Stub header */
+
+#endif /* QMI_CCI_TARGET_H */

--- a/loc_api/loc_api_v02/qmi_cci_target_ext.h
+++ b/loc_api/loc_api_v02/qmi_cci_target_ext.h
@@ -1,0 +1,29 @@
+#ifndef QMI_CCI_TARGET_EXT_H
+#define QMI_CCI_TARGET_EXT_H
+
+#include <stdint.h>
+#include <pthread.h>
+
+typedef struct {
+    uint32_t sig_set;
+    uint32_t timed_out;
+    uint32_t clock;
+    pthread_cond_t cond;
+    pthread_condattr_t attr;
+    pthread_mutex_t mutex;
+} qmi_cci_os_signal_type;
+
+typedef qmi_cci_os_signal_type qmi_client_os_params;
+
+#define QMI_CCI_OS_SIGNAL qmi_cci_os_signal_type
+#define QMI_CCI_OS_SIGNAL_CLEAR(ptr) (ptr)->sig_set = 0
+
+typedef void (*qmi_cci_os_signal_wait_t)(
+    QMI_CCI_OS_SIGNAL *ptr,
+    unsigned int timeout_ms);
+
+static qmi_cci_os_signal_wait_t qmi_cci_os_signal_wait;
+
+#define QMI_CCI_OS_SIGNAL_WAIT qmi_cci_os_signal_wait
+
+#endif /* QMI_CCI_TARGET_EXT_H */

--- a/loc_api/loc_api_v02/qmi_client.h
+++ b/loc_api/loc_api_v02/qmi_client.h
@@ -1,0 +1,106 @@
+#ifndef QMI_CLIENT_H
+#define QMI_CLIENT_H
+
+#include "qmi_idl_lib.h"
+#include "qmi_cci_target_ext.h"
+
+#define QMI_NO_ERR         0
+#define QMI_SERVICE_ERR  (-2)
+
+typedef void *qmi_client_type;
+typedef int qmi_client_error_type;
+
+typedef struct {
+    unsigned int info[5];
+} qmi_service_info;
+
+typedef void (*qmi_client_ind_cb)
+(
+    qmi_client_type user_handle,
+    unsigned int msg_id,
+    void *ind_buf,
+    unsigned int ind_buf_len,
+    void *ind_cb_data
+);
+
+typedef void (*qmi_client_error_cb)
+(
+    qmi_client_type user_handle,
+    qmi_client_error_type error,
+    void *err_cb_data
+);
+
+typedef qmi_client_error_type (*qmi_client_get_any_service_t)
+(
+    qmi_idl_service_object_type service_obj,
+    qmi_service_info *service_info
+);
+
+typedef qmi_client_error_type (*qmi_client_get_service_instance_t)
+(
+    qmi_idl_service_object_type service_obj,
+    unsigned int instance_id,
+    qmi_service_info *service_info
+);
+
+typedef qmi_client_error_type (*qmi_client_init_t)
+(
+    qmi_service_info *service_info,
+    qmi_idl_service_object_type service_obj,
+    qmi_client_ind_cb ind_cb,
+    void *ind_cb_data,
+    qmi_client_os_params *os_params,
+    qmi_client_type *user_handle
+);
+
+typedef qmi_client_error_type (*qmi_client_message_decode_t)
+(
+    qmi_client_type user_handle,
+    qmi_idl_type_of_message_type req_resp_ind,
+    unsigned int message_id,
+    const void *p_src,
+    unsigned int src_len,
+    void *p_dst,
+    unsigned int dst_len
+);
+
+typedef qmi_client_error_type (*qmi_client_notifier_init_t)
+(
+    qmi_idl_service_object_type service_obj,
+    qmi_client_os_params *os_params,
+    qmi_client_type *user_handle
+);
+
+typedef qmi_client_error_type (*qmi_client_register_error_cb_t)
+(
+    qmi_client_type user_handle,
+    qmi_client_error_cb err_cb,
+    void *err_cb_data
+);
+
+typedef qmi_client_error_type (*qmi_client_release_t)
+(
+    qmi_client_type user_handle
+);
+
+typedef qmi_client_error_type (*qmi_client_send_msg_sync_t)
+(
+    qmi_client_type user_handle,
+    unsigned int msg_id,
+    void *req_c_struct,
+    unsigned int req_c_struct_len,
+    void *resp_c_struct,
+    unsigned int resp_c_struct_len,
+    unsigned int timeout_msecs
+);
+
+extern qmi_client_get_any_service_t qmi_client_get_any_service;
+extern qmi_client_get_service_instance_t qmi_client_get_service_instance;
+extern qmi_client_init_t qmi_client_init;
+extern qmi_client_message_decode_t qmi_client_message_decode;
+extern qmi_client_notifier_init_t qmi_client_notifier_init;
+extern qmi_client_register_error_cb_t qmi_client_register_error_cb;
+extern qmi_client_release_t qmi_client_release;
+extern qmi_client_send_msg_sync_t qmi_client_send_msg_sync;
+
+#endif /* QMI_CLIENT_H */

--- a/loc_api/loc_api_v02/qmi_idl_lib.h
+++ b/loc_api/loc_api_v02/qmi_idl_lib.h
@@ -1,0 +1,14 @@
+#ifndef QMI_IDL_LIB_H
+#define QMI_IDL_LIB_H
+
+typedef enum {
+    QMI_IDL_REQUEST = 0,
+    QMI_IDL_RESPONSE,
+    QMI_IDL_INDICATION,
+    QMI_IDL_NUM_MSG_TYPES
+} qmi_idl_type_of_message_type;
+
+typedef struct qmi_idl_service_object *qmi_idl_service_object_type;
+typedef struct qmi_idl_type_table_object qmi_idl_type_table_object;
+
+#endif /* QMI_IDL_LIB_H */

--- a/loc_api/loc_api_v02/qmi_idl_lib_internal.h
+++ b/loc_api/loc_api_v02/qmi_idl_lib_internal.h
@@ -1,0 +1,76 @@
+#ifndef QMI_IDL_LIB_INTERNAL_H
+#define QMI_IDL_LIB_INTERNAL_H
+
+#include <stdint.h>
+
+#include "qmi_idl_lib.h"
+
+#define QMI_IDL_TYPE16(table, type) (((table) << 12) | (type))
+#define QMI_IDL_TYPE88(table, type) (type & 0xFF), (((type & 0xFF00) >> 4) | table)
+
+#define QMI_IDL_FLAGS_OFFSET_IS_16 0x80
+#define QMI_IDL_FLAGS_IS_ARRAY 0x40
+#define QMI_IDL_FLAGS_SZ_IS_16 0x20
+#define QMI_IDL_FLAGS_IS_VARIABLE_LEN 0x10
+
+#define QMI_IDL_OFFSET8(t,f)          ((uint8_t) offsetof(t,f))
+#define QMI_IDL_OFFSET16RELATIVE(t,f) offsetof(t,f)
+#define QMI_IDL_OFFSET16ARRAY(t,f)    ((uint8_t) offsetof(t,f)), \
+                                      ((uint8_t) (offsetof(t,f) >> 8))
+
+
+#define QMI_IDL_FLAG_END_VALUE 0x20
+
+#define QMI_IDL_TLV_FLAGS_LAST_TLV              0x80
+#define QMI_IDL_TLV_FLAGS_OPTIONAL              0x40
+
+#define QMI_IDL_GENERIC_1_BYTE     0
+#define QMI_IDL_GENERIC_2_BYTE     1
+#define QMI_IDL_GENERIC_4_BYTE     2
+#define QMI_IDL_GENERIC_8_BYTE     3
+#define QMI_IDL_STRING             6
+#define QMI_IDL_AGGREGATE          7
+
+typedef struct {
+    uint32_t c_struct_sz;
+    const uint8_t *p_encoded_type_data;
+} qmi_idl_type_table_entry;
+
+typedef struct {
+    uint32_t c_struct_sz;
+    const uint8_t *p_encoded_tlv_data;
+} qmi_idl_message_table_entry;
+
+typedef struct {
+    int8_t (*range_check)(void *val);
+} qmi_idl_range_table_entry;
+
+typedef struct {
+    uint16_t qmi_message_id;
+    uint16_t message_table_message_id;
+    uint16_t max_msg_len;
+} qmi_idl_service_message_table_entry;
+
+struct qmi_idl_type_table_object {
+    uint16_t n_types;
+    uint16_t n_messages;
+    uint8_t n_referenced_tables;
+    const qmi_idl_type_table_entry *p_types;
+    const qmi_idl_message_table_entry *p_messages;
+    const struct qmi_idl_type_table_object **p_referenced_tables;
+    const qmi_idl_range_table_entry *p_ranges;
+};
+
+struct qmi_idl_service_object {
+    uint32_t library_version;
+    uint32_t idl_version;
+    uint32_t service_id;
+    uint32_t max_msg_len;
+    uint16_t n_msgs[QMI_IDL_NUM_MSG_TYPES];
+    const qmi_idl_service_message_table_entry *msgid_to_msg[QMI_IDL_NUM_MSG_TYPES];
+    const qmi_idl_type_table_object *p_type_table;
+    uint32_t idl_minor_version;
+    struct qmi_idl_service_object *parent_service_obj;
+};
+
+#endif /* QMI_IDL_LIB_INTERNAL_H */

--- a/synergy_loc_api/Android.mk
+++ b/synergy_loc_api/Android.mk
@@ -12,8 +12,6 @@ LOCAL_VENDOR_MODULE := true
 LOCAL_SHARED_LIBRARIES := \
     libutils \
     libcutils \
-    libqmi_cci \
-    libqmi_common_so \
     libloc_core \
     libgps.utils \
     libdl \

--- a/utils/loc_socket/Android.mk
+++ b/utils/loc_socket/Android.mk
@@ -20,12 +20,7 @@ LOCAL_CFLAGS := \
     -fno-short-enums \
     -D_ANDROID_
 
-## Includes
-LOCAL_C_INCLUDES := \
-    $(TARGET_OUT_HEADERS)/qmi-framework/inc
-
 LOCAL_HEADER_LIBRARIES := \
-    libqmi_common_headers \
     libloc_core_headers \
     libgps.utils_headers \
     libloc_pla_headers \


### PR DESCRIPTION
- **location: Get rid of proprietary libqmi dependency**
libqmi_cci and libqmi_common_so are proprietary libraries
and we do not have their source code, but the libraries
itself are supplied with the ODM. This means we can
dynamically link them during runtime.

- **loc_api: Introduce libqmi_loader for libqmi symbols**
libqmi_cci and libqmi_common_so are proprietary libraries
and we do not have their source code, but the libraries
itself are supplied with the ODM. This means we can
dynamically link them during runtime.
Add the libqmi_loader that loads the dynamic libraries and
gets the necessary functions.<br />
common_v01.h, qmi_cci_common.h, qmi_cci_target.h,
qmi_cci_target_ext.h, qmi_client.h, qmi_idl_lib.h,
qmi_idl_lib_internal.h headers contain declarations of
functions that are used and will be dynamically obtained.
They also contain the minimum set of structures and
definitions for successful compilation of the libloc_api_v02
library. The headers are partially based on their already
available versions[1]. They have been cleaned and improved
based on the current source code. Some headers are simply
stubs to minimize changes to the current code.

[1] https://github.com/sonyxperiadev/vendor-qcom-opensource-location/tree/aosp/LA.UM.9.16.r1/loc_api/libloc_loader/include